### PR TITLE
Lockout after 3 incorrect login attempts

### DIFF
--- a/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
+++ b/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
@@ -84,7 +84,7 @@ public class LoginActivity extends AppCompatActivity {
             alertDialog.setTitle("Lock out");
             String message = String.format("After attempting registration with incorrect" +
                     "credentials %d times, you are locked out. You will be able to attempt login" +
-                    " again after %d minutes", LOCKOUT_NUMBER, LOCKOUT_MINUTES);
+                    " again after %d minutes", LOCKOUT_NUMBER + 1, LOCKOUT_MINUTES);
             alertDialog.setMessage(message);
             alertDialog.setCancelable(false);
             alertDialog.show();
@@ -94,6 +94,8 @@ public class LoginActivity extends AppCompatActivity {
                     alertDialog.dismiss();
                     mEmailView.setText("");
                     mPasswordView.setText("");
+                    mEmailView.setError(null);
+                    mPasswordView.setError(null);
                 }
             }, LOCKOUT_MINUTES * 60 * 1000);
         }

--- a/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
+++ b/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
@@ -1,5 +1,7 @@
 package kantwonskids.donationtrackerg14b.controller;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Parcelable;
 import android.support.v7.app.AppCompatActivity;
@@ -26,7 +28,6 @@ import kantwonskids.donationtrackerg14b.model.UserList;
  */
 public class LoginActivity extends AppCompatActivity {
 
-
     //private static final int REQUEST_READ_CONTACTS = 0;
 
     /**
@@ -36,6 +37,8 @@ public class LoginActivity extends AppCompatActivity {
     // UI references.
     private AutoCompleteTextView mEmailView;
     private EditText mPasswordView;
+    private int loginAttempts = 0;
+    private static int LOCKOUT_NUMBER = 2;
     // --Commented out by Inspection (11/15/18, 12:36 PM):private View mMainView;
 
     @Override
@@ -74,6 +77,21 @@ public class LoginActivity extends AppCompatActivity {
      * errors are presented and no actual login attempt is made.
      */
     private void attemptLogin() {
+        if (loginAttempts >= LOCKOUT_NUMBER) {
+            AlertDialog alertDialog = new AlertDialog.Builder(LoginActivity.this).create();
+            alertDialog.setTitle("Lock out");
+            alertDialog.setMessage("After attempting registration with incorrect credentials multiple" +
+                    "times, you will be locked out");
+            alertDialog.setButton(AlertDialog.BUTTON_NEUTRAL, "OK",
+                    new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            dialog.dismiss();
+                            lockOut();
+                        }
+                    });
+            alertDialog.show();
+        }
+
         // Reset errors.
         mEmailView.setError(null);
         mPasswordView.setError(null);
@@ -95,9 +113,18 @@ public class LoginActivity extends AppCompatActivity {
         } else {
             focusView.requestFocus();
             mPasswordView.setError(getString(R.string.error_incorrect_password));
+            loginAttempts++;
         }
     }
 
+    /**
+     * method to lock the user out after 3 incorrect password attempts
+     */
+    private void lockOut() {
+        Intent intent = new Intent(this, WelcomeActivity.class);
+        startActivity(intent);
+
+    }
     /**
      * Logs in to the app, once the username and password have passed verification.
      * Shows the main screen with a "success" page.

--- a/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
+++ b/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
@@ -83,7 +83,7 @@ public class LoginActivity extends AppCompatActivity {
             AlertDialog alertDialog = new AlertDialog.Builder(LoginActivity.this).create();
             alertDialog.setTitle("Lock out");
             String message = String.format("After attempting registration with incorrect" +
-                    "credentials %d times, you are locked out. You will be able to attempt login" +
+                    " credentials %d times, you are locked out. You will be able to attempt login" +
                     " again after %d minutes", LOCKOUT_NUMBER + 1, LOCKOUT_MINUTES);
             alertDialog.setMessage(message);
             alertDialog.setCancelable(false);
@@ -111,12 +111,11 @@ public class LoginActivity extends AppCompatActivity {
 
         View focusView = mPasswordView;
 
-        // Get instance of model to compare the username / password with the list of valid users
         //Model model = Model.getInstance();
         UserList userList = Model.getInstance().getUserList();
         User potentialUser = userList.getUser(email);
-
-        if (userList.isValidUser(potentialUser)) {
+        if ((potentialUser != null) &&
+                (potentialUser.getPassword().equals(mPasswordView.getText().toString()))){
             login(potentialUser);
         } else {
             focusView.requestFocus();

--- a/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
+++ b/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
@@ -39,7 +39,8 @@ public class LoginActivity extends AppCompatActivity {
     private AutoCompleteTextView mEmailView;
     private EditText mPasswordView;
     private int loginAttempts = 0;
-    private static int LOCKOUT_NUMBER = 2;
+    private static final int LOCKOUT_NUMBER = 2;
+    private static final int LOCKOUT_MINUTES = 5;
     // --Commented out by Inspection (11/15/18, 12:36 PM):private View mMainView;
 
     @Override
@@ -81,17 +82,20 @@ public class LoginActivity extends AppCompatActivity {
         if (loginAttempts >= LOCKOUT_NUMBER) {
             AlertDialog alertDialog = new AlertDialog.Builder(LoginActivity.this).create();
             alertDialog.setTitle("Lock out");
-            alertDialog.setMessage("After attempting registration with incorrect credentials multiple" +
-                    "times, you are locked out. You will be able to attempt log in again in 5 " +
-                    "minutes.");
+            String message = String.format("After attempting registration with incorrect" +
+                    "credentials %d times, you are locked out. You will be able to attempt login" +
+                    " again after %d minutes", LOCKOUT_NUMBER, LOCKOUT_MINUTES);
+            alertDialog.setMessage(message);
+            alertDialog.setCancelable(false);
             alertDialog.show();
             Handler handler = new Handler();
             handler.postDelayed(new Runnable() {
                 public void run() {
                     alertDialog.dismiss();
-                    lockOut();
+                    mEmailView.setText("");
+                    mPasswordView.setText("");
                 }
-            }, 10000);
+            }, LOCKOUT_MINUTES * 60 * 1000);
         }
 
         // Reset errors.
@@ -119,14 +123,6 @@ public class LoginActivity extends AppCompatActivity {
         }
     }
 
-    /**
-     * method to lock the user out after 3 incorrect password attempts
-     */
-    private void lockOut() {
-        Intent intent = new Intent(this, WelcomeActivity.class);
-        startActivity(intent);
-
-    }
     /**
      * Logs in to the app, once the username and password have passed verification.
      * Shows the main screen with a "success" page.

--- a/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
+++ b/app/src/main/java/kantwonskids/donationtrackerg14b/controller/LoginActivity.java
@@ -3,6 +3,7 @@ package kantwonskids.donationtrackerg14b.controller;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.os.Handler;
 import android.os.Parcelable;
 import android.support.v7.app.AppCompatActivity;
 
@@ -81,15 +82,16 @@ public class LoginActivity extends AppCompatActivity {
             AlertDialog alertDialog = new AlertDialog.Builder(LoginActivity.this).create();
             alertDialog.setTitle("Lock out");
             alertDialog.setMessage("After attempting registration with incorrect credentials multiple" +
-                    "times, you will be locked out");
-            alertDialog.setButton(AlertDialog.BUTTON_NEUTRAL, "OK",
-                    new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int which) {
-                            dialog.dismiss();
-                            lockOut();
-                        }
-                    });
+                    "times, you are locked out. You will be able to attempt log in again in 5 " +
+                    "minutes.");
             alertDialog.show();
+            Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                public void run() {
+                    alertDialog.dismiss();
+                    lockOut();
+                }
+            }, 10000);
         }
 
         // Reset errors.


### PR DESCRIPTION
the dialog just basically blocks the user from doing anything for five minutes after you try to log in incorrectly 3 times. to test this, you don't actually have to wait 5 minutes, just change the number of milliseconds to like 5000 on line 94 of LoginActivity